### PR TITLE
Add Freighter wallet connection

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^19.0.0",
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
-    "stellar-wallets-kit": "^1.0.0"
+    "@creit.tech/stellar-wallets-kit": "^1.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -21,7 +21,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "sonner": "^2.0.6",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "stellar-wallets-kit": "^1.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -25,6 +25,7 @@ import {
 } from "lucide-react"
 import { toast } from "sonner"
 import Link from "next/link"
+import { getWalletKit } from "@/lib/walletKit"
 
 interface Credential {
   id: string
@@ -82,10 +83,17 @@ export default function CredentialDashboard() {
   })
 
   const connectWallet = async () => {
-    const mockAddress = "0x" + Math.random().toString(16).substr(2, 8) + "..." + Math.random().toString(16).substr(2, 4)
-    setUserAddress(mockAddress)
-    setWalletConnected(true)
-    toast.success(`Wallet connected successfully to ${mockAddress}`)
+    try {
+      const kit = getWalletKit()
+      const wallet = await kit.connect()
+      if (wallet && wallet.publicKey) {
+        setUserAddress(wallet.publicKey)
+        setWalletConnected(true)
+        toast.success(`Wallet connected successfully to ${wallet.publicKey}`)
+      }
+    } catch (e) {
+      toast.error("Failed to connect wallet")
+    }
   }
 
   const issueCredential = async () => {

--- a/apps/frontend/src/lib/walletKit.ts
+++ b/apps/frontend/src/lib/walletKit.ts
@@ -1,4 +1,4 @@
-import { WalletsKit, FreighterWallet } from "stellar-wallets-kit"
+import { WalletsKit, FreighterWallet } from "@creit.tech/stellar-wallets-kit"
 
 let kit: WalletsKit | null = null
 

--- a/apps/frontend/src/lib/walletKit.ts
+++ b/apps/frontend/src/lib/walletKit.ts
@@ -1,0 +1,13 @@
+import { WalletsKit, FreighterWallet } from "stellar-wallets-kit"
+
+let kit: WalletsKit | null = null
+
+export const getWalletKit = () => {
+  if (!kit) {
+    kit = new WalletsKit({
+      wallets: [new FreighterWallet()],
+      network: "futurenet",
+    })
+  }
+  return kit
+}


### PR DESCRIPTION
## Summary
- add `stellar-wallets-kit` dependency
- setup a `walletKit` helper configured for Freighter only
- use wallet kit in dashboard page to connect Freighter wallet

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68732278d5a883309fe28f8eee82031e