### PR TITLE
Integrate Stellar Wallet Kit

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -22,6 +22,8 @@
     "react-dom": "^19.0.0",
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1"
+    , "@creit.tech/stellar-wallets-kit": "^1.0.3"
+    , "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -1,6 +1,8 @@
 "use client"
 
 import { useState } from "react"
+import WalletConnector from "@/components/wallet/WalletConnector"
+import { useWalletStore } from "@/stores/wallet"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -11,7 +13,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import {
   Shield,
   CheckCircle,
-  Wallet,
   Key,
   FileText,
   Plus,
@@ -70,8 +71,7 @@ export default function CredentialDashboard() {
     },
   ])
 
-  const [walletConnected, setWalletConnected] = useState(false)
-  const [userAddress, setUserAddress] = useState("")
+  const { connected, publicKey } = useWalletStore()
   const [activeTab, setActiveTab] = useState("dashboard")
   const [issuanceForm, setIssuanceForm] = useState({
     userAddress: "",
@@ -81,12 +81,6 @@ export default function CredentialDashboard() {
     credentialId: "",
   })
 
-  const connectWallet = async () => {
-    const mockAddress = "0x" + Math.random().toString(16).substr(2, 8) + "..." + Math.random().toString(16).substr(2, 4)
-    setUserAddress(mockAddress)
-    setWalletConnected(true)
-    toast.success(`Wallet connected successfully to ${mockAddress}`)
-  }
 
   const issueCredential = async () => {
     const newCredential: Credential = {
@@ -185,20 +179,15 @@ export default function CredentialDashboard() {
           </div>
 
           {/* Wallet Status */}
-          {!walletConnected ? (
-            <Button
-              onClick={connectWallet}
-              className="bg-gradient-to-r from-black to-gray-800 hover:from-gray-800 hover:to-black text-white shadow-lg"
-            >
-              <Wallet className="w-4 h-4 mr-2" />
-              Connect Wallet
-            </Button>
-          ) : (
-            <div className="flex items-center space-x-2 bg-green-50 px-4 py-2 rounded-xl border-2 border-green-200">
-              <CheckCircle className="h-4 w-4 text-green-600" />
-              <span className="text-green-700 text-sm font-medium">{userAddress}</span>
-            </div>
-          )}
+          <div className="flex items-center space-x-2">
+            {connected && (
+              <div className="flex items-center space-x-2 bg-green-50 px-4 py-2 rounded-xl border-2 border-green-200">
+                <CheckCircle className="h-4 w-4 text-green-600" />
+                <span className="text-green-700 text-sm font-medium">{publicKey}</span>
+              </div>
+            )}
+            <WalletConnector />
+          </div>
         </div>
 
         {/* Main Content */}

--- a/apps/frontend/src/components/wallet/WalletConnector.tsx
+++ b/apps/frontend/src/components/wallet/WalletConnector.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { useWalletStore, SupportedWallet } from "@/stores/wallet"
+
+export default function WalletConnector() {
+  const { connected, walletType, connectWallet, disconnectWallet } = useWalletStore()
+  const [selected, setSelected] = useState<SupportedWallet>('freighter')
+
+  const handleConnect = async () => {
+    await connectWallet(selected)
+  }
+
+  const handleDisconnect = async () => {
+    await disconnectWallet()
+  }
+
+  if (connected) {
+    return (
+      <Button onClick={handleDisconnect} className="bg-red-600 text-white hover:bg-red-700">
+        {`Desconectar ${walletType}`}
+      </Button>
+    )
+  }
+
+  return (
+    <div className="flex items-center space-x-2">
+      <Select value={selected} onValueChange={(v: SupportedWallet) => setSelected(v)}>
+        <SelectTrigger className="w-32">
+          <SelectValue placeholder="Wallet" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="freighter">Freighter</SelectItem>
+          <SelectItem value="xbull">xBull</SelectItem>
+        </SelectContent>
+      </Select>
+      <Button onClick={handleConnect} className="bg-gradient-to-r from-black to-gray-800 text-white">
+        Conectar Wallet
+      </Button>
+    </div>
+  )
+}

--- a/apps/frontend/src/stores/wallet.ts
+++ b/apps/frontend/src/stores/wallet.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import { StellarWalletsKit } from '@creit.tech/stellar-wallets-kit'
+
+export type SupportedWallet = 'freighter' | 'xbull'
+
+interface WalletState {
+  connected: boolean
+  walletType: SupportedWallet | null
+  publicKey: string | null
+  connectWallet: (wallet: SupportedWallet) => Promise<void>
+  disconnectWallet: () => Promise<void>
+}
+
+const kit = new StellarWalletsKit({ network: 'futurenet' })
+
+export const useWalletStore = create<WalletState>()(
+  persist(
+    (set) => ({
+      connected: false,
+      walletType: null,
+      publicKey: null,
+      connectWallet: async (wallet: SupportedWallet) => {
+        const { publicKey } = await kit.connect(wallet)
+        set({ connected: true, walletType: wallet, publicKey })
+      },
+      disconnectWallet: async () => {
+        await kit.disconnect()
+        set({ connected: false, walletType: null, publicKey: null })
+      },
+    }),
+    { name: 'wallet-store' }
+  )
+)


### PR DESCRIPTION
## Summary
- integrate `@creit.tech/stellar-wallets-kit` and `zustand`
- create zustand wallet store with persistence
- add wallet connection component with wallet selector
- wire connector into dashboard page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_687327f13a0c83309c16310e9ed1d506