### PR TITLE
Integrate soroban SDK

### DIFF
--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -1,1 +1,13 @@
-# The documentation to the frontend
+# StarProof Frontend
+
+## Environment Variables
+
+This app expects the Soroban contract ID to be supplied via `NEXT_PUBLIC_CONTRACT_ID`.
+Create a `.env.local` file in this directory with the following contents:
+
+```bash
+NEXT_PUBLIC_CONTRACT_ID="<your_contract_id>"
+```
+
+The frontend uses `@stellar/soroban-client` to communicate with the contract on
+the Stellar testnet.

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -18,6 +18,7 @@
     "lucide-react": "^0.525.0",
     "next": "^15.3.5",
     "next-themes": "^0.4.6",
+    "@stellar/soroban-client": "^0.10.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "sonner": "^2.0.6",

--- a/apps/frontend/src/lib/soroban.ts
+++ b/apps/frontend/src/lib/soroban.ts
@@ -1,0 +1,35 @@
+import { Contract, SorobanRpc, xdr, nativeToScVal, scValToNative } from "@stellar/soroban-client";
+
+const rpcUrl = "https://soroban-testnet.stellar.org";
+
+export const rpc = new SorobanRpc.Server(rpcUrl, { allowHttp: true });
+
+const contractId = process.env.NEXT_PUBLIC_CONTRACT_ID || "";
+
+const contract = new Contract(contractId);
+
+export async function issueCertificate(
+  id: string,
+  owner: string,
+  metadataHash: string
+) {
+  const args = [
+    nativeToScVal(id, { type: "string" }),
+    nativeToScVal(owner, { type: "address" }),
+    nativeToScVal(metadataHash, { type: "string" }),
+  ];
+  const result = await rpc.call(contract, "issue_certificate", ...args);
+  return scValToNative(result as xdr.ScVal);
+}
+
+export async function getCertificateDetails(id: string) {
+  const args = [nativeToScVal(id, { type: "string" })];
+  const result = await rpc.call(contract, "get_certificate_details", ...args);
+  return scValToNative(result as xdr.ScVal);
+}
+
+export async function revokeCertificate(id: string) {
+  const args = [nativeToScVal(id, { type: "string" })];
+  const result = await rpc.call(contract, "revoke_certificate", ...args);
+  return scValToNative(result as xdr.ScVal);
+}


### PR DESCRIPTION
## Summary
- wire soroban client into frontend
- expose contract ID via `NEXT_PUBLIC_CONTRACT_ID`
- add helper to call Soroban contract from the dashboard

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68732c943a288330981567cee3a156f0