### PR TITLE
Add certificate query and verification

### DIFF
--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -11,7 +11,11 @@ import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
 import { ArrowLeft, CheckCircle } from "lucide-react";
 
-import { issueCertificateOnChain } from "@/components/modules/certificate/services/certificate.service";
+import {
+  issueCertificateOnChain,
+  getCertificateDetails,
+  verifyCertificate,
+} from "@/components/modules/certificate/services/certificate.service";
 
 interface ContractCertificate {
   id: string;
@@ -34,6 +38,27 @@ export default function CredentialDashboard() {
 
   const [certificate, setCertificate] = useState<ContractCertificate>();
   const [error, setError] = useState<string | null>(null);
+
+  const verifyOnChain = async () => {
+    if (!certificate) return;
+
+    try {
+      const details = await getCertificateDetails(certificate.id);
+      const isValid = await verifyCertificate(
+        certificate.id,
+        certificate.metadataHash
+      );
+
+      setCertificate({
+        ...certificate,
+        owner: details.owner,
+        metadataHash: details.metadataHash,
+        status: isValid ? "issued" : "expired",
+      });
+    } catch (e) {
+      console.error("Verification error", e);
+    }
+  };
 
   const handleChange = (field: keyof typeof form, value: string) => {
     setForm((prev) => ({ ...prev, [field]: value }));
@@ -161,6 +186,9 @@ export default function CredentialDashboard() {
                 <Badge variant="outline" className="mt-2">
                   {certificate.status}
                 </Badge>
+                <Button onClick={verifyOnChain} size="sm" className="mt-2">
+                  Verify Certificate
+                </Button>
               </div>
             )}
           </CardContent>

--- a/apps/frontend/src/components/modules/certificate/hooks/useCertificateFlow.ts
+++ b/apps/frontend/src/components/modules/certificate/hooks/useCertificateFlow.ts
@@ -1,7 +1,11 @@
 "use client"
 
 import { useState } from "react"
-import { issueCertificateOnChain } from "../services/certificate.service"
+import {
+  issueCertificateOnChain,
+  getCertificateDetails,
+  verifyCertificate as verifyCertificateOnChain,
+} from "../services/certificate.service"
 import { CertificateData, ContractCertificate } from "../types/certificates.types"
 
 export const useCertificateFlow = () => {
@@ -29,9 +33,22 @@ export const useCertificateFlow = () => {
     setStep(1)
   }
 
-  const verifyCertificate = () => {
-    if (!contractCertificate) return
-    setContractCertificate({ ...contractCertificate, status: "issued" })
+  const verifyCertificate = async () => {
+    if (!contractCertificate || !certId) return
+
+    const details = await getCertificateDetails(certId)
+    const isValid = await verifyCertificateOnChain(
+      certId,
+      contractCertificate.metadataHash
+    )
+
+    setContractCertificate({
+      ...contractCertificate,
+      owner: details.owner,
+      metadataHash: details.metadataHash,
+      status: isValid ? "issued" : "expired",
+    })
+
     setStep(2)
   }
 


### PR DESCRIPTION
## Summary
- implement `getCertificateDetails` and `verifyCertificate` to interact with Soroban contract
- expose new verification logic in `useCertificateFlow`
- allow verifying issued certificate from dashboard page

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_b_6874adf120048330a9a18b7ddd62615c