### PR TITLE
Fix lint warnings and translate comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > **Verifiable credentials on Stellar with dynamic on-chain and off-chain badges**
 
 Prototype MVP that lets issuers mint Verifiable Credentials (VCs) and dynamic badges backed by the Stellar blockchain.  
-_(The section **“Propuestas para hacer StarProof más innovador”** is intentionally omitted for now)._
+_(The section **"Proposals to make StarProof more innovative"** is intentionally omitted for now)._ 
 
 ---
 

--- a/apps/frontend/src/components/lib/stellar.ts
+++ b/apps/frontend/src/components/lib/stellar.ts
@@ -1,4 +1,3 @@
-import { randomBytes } from "crypto";
 import * as StellarSDK from "@stellar/stellar-sdk";
 
 /**
@@ -32,18 +31,10 @@ export function buildCertificateTransaction(
  */
 export function buildCertificateInvokeOperation(
   contractAddress: string,
-  wasmHash: string,
+  _wasmHash: string,
   entrypoint: string,
   args: StellarSDK.xdr.ScVal[]
 ): StellarSDK.xdr.Operation {
-  const wasmHashVal = StellarSDK.nativeToScVal(Buffer.from(wasmHash, "hex"), {
-    type: "bytes",
-  });
-
-  const saltVal = StellarSDK.nativeToScVal(Buffer.from(randomBytes(32)), {
-    type: "bytes",
-  });
-
   const operation = StellarSDK.Operation.invokeHostFunction({
     auth: [],
     func: StellarSDK.xdr.HostFunction.hostFunctionTypeInvokeContract(

--- a/apps/frontend/src/components/modules/certificate/services/certificate.service.ts
+++ b/apps/frontend/src/components/modules/certificate/services/certificate.service.ts
@@ -14,7 +14,7 @@ import {
 import { sorobanServer } from "@/components/core/config/stellar/stellar";
 
 /**
- * Enviar transacción firmada por Freighter
+ * Send a transaction signed by Freighter
  */
 async function submitSignedTransactionXdr(
   signedXdr: string,
@@ -29,7 +29,7 @@ async function submitSignedTransactionXdr(
 }
 
 /**
- * Emite un certificado en la blockchain usando el contrato Soroban actualizado
+ * Issue a certificate on the blockchain using the updated Soroban contract
  */
 export const issueCertificateOnChain = async (
   certData: CertificateData

--- a/apps/frontend/src/components/modules/certificate/types/certificates.types.ts
+++ b/apps/frontend/src/components/modules/certificate/types/certificates.types.ts
@@ -1,25 +1,25 @@
 export interface CertificateMetadata {
-    to: string // Dirección del destinatario (usuario)
-    action: string // Acción ejecutada en el contrato (e.g. CERTIFICATE_ISSUANCE)
+    to: string // Recipient address
+    action: string // Action executed in the contract (e.g. CERTIFICATE_ISSUANCE)
     expires: boolean
     expirationDate?: string
     certificateHash: string
-    blockchainTxId?: string // ID de la transacción en blockchain
+    blockchainTxId?: string // Blockchain transaction ID
   }
   
   export interface CertificateData {
-    // Información general del certificado
+    // General certificate information
     certificateId: string
     certificateType: string
     issueDate: string
     description: string
   
-    // Datos del emisor
+    // Issuer data
     issuerName: string
-    issuerAddress: string // Dirección blockchain
+    issuerAddress: string // Blockchain address
     issuerContact: string
   
-    // Metadatos de contrato
+    // Contract metadata
     metadata: CertificateMetadata
   }
   

--- a/apps/frontend/src/components/modules/certificate/ui/CertificatePage.tsx
+++ b/apps/frontend/src/components/modules/certificate/ui/CertificatePage.tsx
@@ -10,7 +10,7 @@ import { Label } from "@/components/ui/label";
 import Link from "next/link";
 import { ArrowLeft, CheckCircle } from "lucide-react";
 import { issueCertificateOnChain } from "@/components/modules/certificate/services/certificate.service";
-import { useScroll, useTransform } from "framer-motion";
+import { useScroll } from "framer-motion";
 import { CertificateCard } from "./CertificateCard";
 import StarsBackground from "../../background/StarsBackground";
 
@@ -41,7 +41,6 @@ export default function CredentialDashboard() {
     target: containerRef,
     offset: ["start start", "end end"],
   });
-  const parallaxY = useTransform(scrollYProgress, [0, 1], [0, -100]);
 
   const handleChange = (field: keyof typeof form, value: string) => {
     setForm((prev) => ({ ...prev, [field]: value }));
@@ -50,13 +49,13 @@ export default function CredentialDashboard() {
   const issueCertificate = async () => {
     setError(null);
     if (!address) {
-      console.warn("⚠️ Wallet no conectada. Intentando conectar...");
+      console.warn("⚠️ Wallet not connected. Attempting to connect...");
       await handleConnect();
       return;
     }
     if (!form.owner || !form.metadataHash) {
       setError(
-        "⚠️ Debes ingresar todos los campos obligatorios (Owner y Metadata Hash)."
+        "⚠️ You must complete all required fields (Owner and Metadata Hash)."
       );
       return;
     }
@@ -69,13 +68,11 @@ export default function CredentialDashboard() {
       },
     };
     try {
-      console.log("🚀 Enviando parámetros a issueCertificateOnChain:", params);
       const issued = await issueCertificateOnChain(params);
-      console.log("✅ Certificado emitido correctamente:", issued);
       setCertificate(issued);
       setForm({ certId: "", owner: "", metadataHash: "" });
     } catch (e: unknown) {
-      console.error("❌ Ocurrió un error al emitir el certificado:", e);
+      console.error("❌ An error occurred while issuing the certificate:", e);
       if (
         e &&
         typeof e === "object" &&
@@ -84,7 +81,7 @@ export default function CredentialDashboard() {
       ) {
         setError(`📛 ${e.message}`);
       } else {
-        setError("📛 Error desconocido al emitir el certificado.");
+        setError("📛 Unknown error while issuing the certificate.");
       }
     }
   };
@@ -138,7 +135,7 @@ export default function CredentialDashboard() {
                 id="certId"
                 value={form.certId}
                 onChange={(e) => handleChange("certId", e.target.value)}
-                placeholder="Ej: CERT-001"
+                placeholder="e.g. CERT-001"
                 className="bg-gray-800 border-gray-700 text-white placeholder:text-gray-500 focus:ring-[#0066ff]"
               />
             </div>
@@ -150,7 +147,7 @@ export default function CredentialDashboard() {
                 id="owner"
                 value={form.owner}
                 onChange={(e) => handleChange("owner", e.target.value)}
-                placeholder="Ej: GC..."
+                placeholder="e.g. GC..."
                 className="bg-gray-800 border-gray-700 text-white placeholder:text-gray-500 focus:ring-[#0066ff]"
               />
             </div>
@@ -162,7 +159,7 @@ export default function CredentialDashboard() {
                 id="metadataHash"
                 value={form.metadataHash}
                 onChange={(e) => handleChange("metadataHash", e.target.value)}
-                placeholder="Ej: certificado-abc-hash"
+                placeholder="e.g. certificate-abc-hash"
                 className="bg-gray-800 border-gray-700 text-white placeholder:text-gray-500 focus:ring-[#0066ff]"
               />
             </div>

--- a/apps/frontend/src/components/modules/certificate/ui/CertificatePage.tsx
+++ b/apps/frontend/src/components/modules/certificate/ui/CertificatePage.tsx
@@ -10,7 +10,6 @@ import { Label } from "@/components/ui/label";
 import Link from "next/link";
 import { ArrowLeft, CheckCircle } from "lucide-react";
 import { issueCertificateOnChain } from "@/components/modules/certificate/services/certificate.service";
-import { useScroll } from "framer-motion";
 import { CertificateCard } from "./CertificateCard";
 import StarsBackground from "../../background/StarsBackground";
 
@@ -37,10 +36,6 @@ export default function CredentialDashboard() {
   const [error, setError] = useState<string | null>(null);
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const { scrollYProgress } = useScroll({
-    target: containerRef,
-    offset: ["start start", "end end"],
-  });
 
   const handleChange = (field: keyof typeof form, value: string) => {
     setForm((prev) => ({ ...prev, [field]: value }));


### PR DESCRIPTION
## Summary
- remove unused values in Stellar helper
- clean up CertificatePage and translate messages to English
- convert service and type comments to English
- tweak README wording

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `cargo test` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_b_6874d1a9688483308c0f84a41444b3a2