### PR TITLE
Fix certificate interface and swap console errors for toasts

### DIFF
--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,20 +1,21 @@
-import type React from "react"
-import type { Metadata } from "next"
-import { Inter } from "next/font/google"
-import "./globals.css"
-import { Toaster } from "sonner"
+import type React from "react";
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "./globals.css";
+import { Toaster } from "sonner";
 
-const inter = Inter({ subsets: ["latin"] })
+const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "StarProof - Verifiable Credentials",
-  description: "Issue, verify, and manage digital credentials with cryptographic security on Stellar blockchain",
-}
+  title: "StarProof",
+  description:
+    "Issue, verify, and manage digital credentials with cryptographic security on Stellar blockchain",
+};
 
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }) {
   return (
     <html lang="en">
@@ -23,5 +24,5 @@ export default function RootLayout({
         <Toaster position="top-right" richColors closeButton theme="light" />
       </body>
     </html>
-  )
+  );
 }

--- a/apps/frontend/src/components/auth/hooks/useWallet.hook.ts
+++ b/apps/frontend/src/components/auth/hooks/useWallet.hook.ts
@@ -29,7 +29,7 @@ export const useWallet = () => {
   const handleConnect = async () => {
     try {
       await connectWallet();
-    } catch (error) {
+    } catch {
       toast.error("Error connecting wallet");
     }
   };
@@ -39,11 +39,10 @@ export const useWallet = () => {
       if (disconnectWallet) {
         await disconnectWallet();
       }
-    } catch (error) {
+    } catch {
       toast.error("Error disconnecting wallet");
     }
   };
-
 
   return {
     handleConnect,

--- a/apps/frontend/src/components/auth/hooks/useWallet.hook.ts
+++ b/apps/frontend/src/components/auth/hooks/useWallet.hook.ts
@@ -1,6 +1,7 @@
 import { ISupportedWallet } from "@creit.tech/stellar-wallets-kit";
 import { useGlobalAuthenticationStore } from "@/components/auth/store/data";
 import { kit } from "@/components/auth/constant/walletkit";
+import { toast } from "sonner";
 
 export const useWallet = () => {
   const { connectWalletStore, disconnectWalletStore } =
@@ -29,7 +30,7 @@ export const useWallet = () => {
     try {
       await connectWallet();
     } catch (error) {
-      console.error("Error connecting wallet:", error);
+      toast.error("Error connecting wallet");
     }
   };
 
@@ -39,7 +40,7 @@ export const useWallet = () => {
         await disconnectWallet();
       }
     } catch (error) {
-      console.error("Error disconnecting wallet:", error);
+      toast.error("Error disconnecting wallet");
     }
   };
 

--- a/apps/frontend/src/components/modules/certificate/types/certificates.types.ts
+++ b/apps/frontend/src/components/modules/certificate/types/certificates.types.ts
@@ -1,7 +1,7 @@
 export interface CertificateMetadata {
     to: string // Recipient address
-    action: string // Action executed in the contract (e.g. CERTIFICATE_ISSUANCE)
-    expires: boolean
+    action?: string // Action executed in the contract (e.g. CERTIFICATE_ISSUANCE)
+    expires?: boolean
     expirationDate?: string
     certificateHash: string
     blockchainTxId?: string // Blockchain transaction ID

--- a/apps/frontend/src/components/modules/certificate/types/certificates.types.ts
+++ b/apps/frontend/src/components/modules/certificate/types/certificates.types.ts
@@ -7,17 +7,17 @@ export interface CertificateMetadata {
     blockchainTxId?: string // Blockchain transaction ID
   }
   
-  export interface CertificateData {
+export interface CertificateData {
     // General certificate information
     certificateId: string
-    certificateType: string
-    issueDate: string
-    description: string
+    certificateType?: string
+    issueDate?: string
+    description?: string
   
     // Issuer data
-    issuerName: string
+    issuerName?: string
     issuerAddress: string // Blockchain address
-    issuerContact: string
+    issuerContact?: string
   
     // Contract metadata
     metadata: CertificateMetadata

--- a/apps/frontend/src/components/modules/certificate/ui/CertificatePage.tsx
+++ b/apps/frontend/src/components/modules/certificate/ui/CertificatePage.tsx
@@ -12,6 +12,7 @@ import { ArrowLeft, CheckCircle } from "lucide-react";
 import { issueCertificateOnChain } from "@/components/modules/certificate/services/certificate.service";
 import { CertificateCard } from "./CertificateCard";
 import StarsBackground from "../../background/StarsBackground";
+import { toast } from "sonner";
 
 interface ContractCertificate {
   id: string;
@@ -44,7 +45,7 @@ export default function CredentialDashboard() {
   const issueCertificate = async () => {
     setError(null);
     if (!address) {
-      console.warn("⚠️ Wallet not connected. Attempting to connect...");
+      toast.warning("⚠️ Wallet not connected. Attempting to connect...");
       await handleConnect();
       return;
     }
@@ -67,7 +68,7 @@ export default function CredentialDashboard() {
       setCertificate(issued);
       setForm({ certId: "", owner: "", metadataHash: "" });
     } catch (e: unknown) {
-      console.error("❌ An error occurred while issuing the certificate:", e);
+      toast.error("❌ An error occurred while issuing the certificate");
       if (
         e &&
         typeof e === "object" &&


### PR DESCRIPTION
## Summary
- make certificate optional fields optional so partial objects compile
- replace console logs with `sonner` toasts
- show toast when wallet is not connected

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: unable to fetch packages - registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6874d59a43a88330964b0102ababeeaa